### PR TITLE
Add issue template Done

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,42 @@
+name: 🐛 Bug Report
+description: Report an issue to help improve the project
+title: "[Bug]: "
+labels: ["bug", "triage"]
+assignees:
+  - octocat
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our Code of Conduct.
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,35 @@
+name: 📄 Documentation
+description: Report an issue related to documentation
+title: "Documentation: "
+labels: ["documentation"]
+assignees:
+  - octocat
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to make our documentation better
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Description
+      description: A clear and concise description of what the issue is.
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: checkboxes
+    id: no_prev_same
+    attributes:
+      label: 👀 Have you spent some time to check if this issue has been raised before?
+      description: Have you Googled for a similar issue or checked our older issues for a similar bug?
+      options:
+        - label: I checked and didn't find similar issue
+          required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: 🏢 Have you read the Code of Conduct?
+      description: By submitting this issue, you agree to follow our Code of Conduct.
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true          

--- a/.github/ISSUE_TEMPLATE/features.yaml
+++ b/.github/ISSUE_TEMPLATE/features.yaml
@@ -1,0 +1,35 @@
+name: 💡 Feature
+description: Submit a proposal for a new feature
+title: "Feature: "
+labels: ["enhancement"]
+assignees:
+  - octocat
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out our feature request form
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Feature description
+      description: A clear and concise description of what the feature is.
+      placeholder: You should add ...
+    validations:
+      required: true
+  - type: checkboxes
+    id: no_prev_same
+    attributes:
+      label: 👀 Have you spent some time to check if this issue has been raised before?
+      description: Have you Googled for a similar issue or checked our older issues for a similar bug?
+      options:
+        - label: I checked and didn't find similar issue
+          required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: 🏢 Have you read the Code of Conduct?
+      description: By submitting this issue, you agree to follow our Code of Conduct.
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true          


### PR DESCRIPTION
Closes  #12  . 

**Changes :** 
- [x] 🐛 Bug Report Issue template done
- [x] 📄 Documentation Issue template done
- [x] 💡 Feature Issue template done

**Look the Changes :** 

3 Templates .. 
<img src="https://user-images.githubusercontent.com/74618071/156630338-3c4fca65-40bd-4942-a2b1-882d82e37545.png" width="80%" />

**1.  Bug Report Issue template**
<img src="https://user-images.githubusercontent.com/74618071/156630756-c1ff6515-ed9f-48da-8704-11a1604d58cb.png" width="80%" />

**2. Documentation Issue template**
<img src="https://user-images.githubusercontent.com/74618071/156631050-11e5070e-9bbb-452b-8485-c32dee519db9.png" width="80%" />

**3.  Feature Issue template**
<img src="https://user-images.githubusercontent.com/74618071/156631138-d7b21a40-63e9-4b58-8288-b9ae5f572ac4.png" width="80%" />




- [x] I agree to follow this project's Code of Conduct . 

**Amit Maity** - GSSoC'22 Contributor. 

